### PR TITLE
BugFix - Update YouTube URL Format to @username Style

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build.environment]
+PYTHON_VERSION = "3.9"

--- a/src/config/social.ts
+++ b/src/config/social.ts
@@ -106,6 +106,6 @@ export const SOCIAL_SITES: {
         shieldBadge:
             'https://img.shields.io/badge/youtube-%23EE4831.svg?&style=for-the-badge&logo=youtube&logoColor=white',
         title: 'YouTube',
-        href: (username: string) => `https://www.youtube.com/user/${username}`,
+        href: (username: string) => `https://www.youtube.com/@${username}`,
     },
 };


### PR DESCRIPTION
# Update YouTube URL Format to `@username` Style

This PR updates the `href` function to use the modern YouTube handle format (`@username`) instead of the legacy `user/username` URL structure.

**✅ Before:**

```ts
href: (username: string) => `https://www.youtube.com/user/${username}`,
```

**✅ After:**

```ts
href: (username: string) => `https://www.youtube.com/@${username}`,
```

This change ensures consistency with the current YouTube URL standard and improves compatibility with newer channels that use handles.

Closes #145 issue.